### PR TITLE
use ControlUiTestsBase instead

### DIFF
--- a/src/Orc.Snapshots.Tests/UI/Base/StyledControlTestFacts.cs
+++ b/src/Orc.Snapshots.Tests/UI/Base/StyledControlTestFacts.cs
@@ -10,7 +10,7 @@ using Theming;
 using FrameworkElement = System.Windows.FrameworkElement;
 
 //TODO:Vladimir: create base type in Orc.Automation
-public abstract class StyledControlTestFacts<TControl> : ControlUiTestFactsBase<TControl>
+public abstract class StyledControlTestFacts<TControl> : ControlUiTestsBase<TControl>
     where TControl : FrameworkElement
 {
     protected TestHostAutomationControl TestHost { get; private set; }


### PR DESCRIPTION
fix:
Orc.Snapshots:
C:\CI_WS\Ws\266279\Source\Orc_Snapshots\src\Orc.Snapshots.Tests\UI\Base\StyledControlTestFacts.cs(13,58): error CS0619: 'ControlUiTestFactsBase<TControl>' is obsolete: 'Use `ControlUiTestsBase` instead. Will be removed in version 6.0.0.' [C:\CI_WS\Ws\266279\Source\Orc_Snapshots\src\Orc.Snapshots.Tests\Orc.Snapshots.Tests.csproj::TargetFramework=net8.0-windows]